### PR TITLE
updates "getting started" section

### DIFF
--- a/app/html/README.md
+++ b/app/html/README.md
@@ -11,9 +11,10 @@ Storybook runs outside of your app.
 So you can develop UI components in isolation without worrying about app specific dependencies and requirements.
 
 ## Getting Started
+(**note:** To get the alpha version of Storybook for HTML to run correctly you will need to install an alpha version of `cli` (included in the commands below).)
 
 ```sh
-npm i -g @storybook/cli
+npm i -g @storybook/cli@v4.0.0-alpha.10
 cd my-app
 getstorybook --html
 ```


### PR DESCRIPTION


Issue: Storybook for HTML Alpha needs to have an alpha version of the cli installed

## What I did

- adds a note about needing an alpha version of the `cli` to run the alpha version of Storybook for HTML
- includes the current(?) alpha version in the getting started commands

## How to test

Does this need an update to the documentation?

This is updated

If your answer is yes to any of these, please make sure to include it in your PR.
